### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ urllib3
 tqdm
 
 opencv-python
+lxml


### PR DESCRIPTION
The requirements file does not contain `lxml` module which is required to run `oid_to_pascal_voc_xml.py`.